### PR TITLE
Setup FedNow in docker

### DIFF
--- a/FedSystems/.env.example
+++ b/FedSystems/.env.example
@@ -10,6 +10,7 @@ FRB_LEGAL_NAME="FRB Tungsten"
 
 # Service ports (ach-backend)
 APP_ACH_PORT=8310 # Originally 8001
+APP_FEDNOW_PORT=8514 # Originally 8001
 
 # Server network identity for LAN deployments
 # Keep localhost for single-machine dev; set SERVER_IP to your LAN IP on a shared network.

--- a/FedSystems/FedNow/Dockerfile
+++ b/FedSystems/FedNow/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+WORKDIR /FedNow
+
+# Install Docker CLI
+RUN apt-get update && apt-get install -y docker.io && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "main:fednow", "--host", "0.0.0.0", "--port", "8000"]

--- a/FedSystems/FedNow/main.py
+++ b/FedSystems/FedNow/main.py
@@ -1,2 +1,31 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+import os
+
+load_dotenv()  # Load environment variables from .env file
+
+# --- FRB Configuration ---
+FRB_ROUTING_NUMBER = os.environ.get("FRB_ROUTING_NUMBER", "090000515")
+FRB_LEGAL_NAME = os.environ.get("FRB_LEGAL_NAME", "Federal Reserve Bank")
+
+fednow = FastAPI(title="FedNow API", version="1.0")
+
+fednow.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@fednow.get("/health", tags=["Health"])
+def health_check():
+    return {"status": "FedNow API is healthy"}
+
+@fednow.get("/frb-info", tags=["FRB"])
+def get_frb_info():
+    return {
+        "routing_number": FRB_ROUTING_NUMBER,
+        "legal_name": FRB_LEGAL_NAME
+    }

--- a/FedSystems/FedNow/main.py
+++ b/FedSystems/FedNow/main.py
@@ -1,0 +1,2 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware

--- a/FedSystems/FedNow/requirements.txt
+++ b/FedSystems/FedNow/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.103.0
+uvicorn[standard]==0.23.2
+paramiko==3.4.0
+pydantic==2.4.2
+psycopg2-binary==2.9.10
+python-dotenv==1.0.0

--- a/FedSystems/docker-compose.yml
+++ b/FedSystems/docker-compose.yml
@@ -36,6 +36,24 @@ services:
       - sftp_data:/app/sftp_data
       - /var/run/docker.sock:/var/run/docker.sock
 
+  fednow-backend:
+    image: fedsystems-fednow
+    build:
+      context: ./FedNow
+    ports:
+      - "${APP_FEDNOW_PORT}:8000"
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      - SFTP_HOST_PORT=${SFTP_FEDNOW_HOST_PORT}
+      - REACT_PORT=${REACT_PORT}
+      - VITE_PORT=${VITE_PORT}
+      - FRB_ROUTING_NUMBER=${FRB_ROUTING_NUMBER}
+      - FRB_LEGAL_NAME=${FRB_LEGAL_NAME}
+    depends_on:
+      - postgres
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
   sftp:
     container_name: fedsystems-sftp
     image: atmoz/sftp

--- a/FedSystems/docker-compose.yml
+++ b/FedSystems/docker-compose.yml
@@ -44,7 +44,6 @@ services:
       - "${APP_FEDNOW_PORT}:8000"
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-      - SFTP_HOST_PORT=${SFTP_FEDNOW_HOST_PORT}
       - REACT_PORT=${REACT_PORT}
       - VITE_PORT=${VITE_PORT}
       - FRB_ROUTING_NUMBER=${FRB_ROUTING_NUMBER}

--- a/FedSystems/docker-compose.yml
+++ b/FedSystems/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - postgres
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./SFTP_Keys:/FedNow/SFTP_Keys:ro
 
   sftp:
     container_name: fedsystems-sftp

--- a/FedSystems/generate_keys.py
+++ b/FedSystems/generate_keys.py
@@ -102,6 +102,25 @@ def main():
     for key in sorted(banks.keys()):
         bank_name = banks[key]
         create_key(bank_name, str(keys_dir))
+
+    # Generate key for FRB
+    frb_dir = keys_dir / 'frb'
+    frb_dir.mkdir(exist_ok=True)
+    frb_key_file = frb_dir / 'id_rsa'
+    if not frb_key_file.exists():
+        print("Generating 4096-bit RSA keypair for FRB...")
+        result = subprocess.run([
+            'ssh-keygen',
+            '-t', 'rsa',
+            '-b', '4096',
+            '-f', str(frb_key_file),
+            '-N', ''
+        ], capture_output=True)
+        
+        if result.returncode != 0:
+            print("Failed to generate key for FRB.")
+        else:
+            print(f"Created {frb_key_file} and {frb_key_file}.pub")
     
     print("Done.")
 


### PR DESCRIPTION
This pull request introduces a new FastAPI-based FedNow backend service to the system, including its Dockerization, configuration, and integration into the existing Docker Compose setup. It also adds support for FRB-specific configuration and key generation. The most important changes are grouped below:

**FedNow Backend Service Addition:**

* Added a new FastAPI application in `FedSystems/FedNow/main.py` with endpoints for health checks and FRB information, loading configuration from environment variables.
* Created a `requirements.txt` for the new service, specifying dependencies such as `fastapi`, `uvicorn`, and `python-dotenv`.
* Added a `Dockerfile` to containerize the FedNow backend, installing dependencies and exposing the service on port 8000.

**Docker Compose and Environment Configuration:**

* Integrated the new `fednow-backend` service into `docker-compose.yml`, including build context, environment variables, port mapping, and necessary volumes.
* Updated `.env.example` to include a new `APP_FEDNOW_PORT` variable for configuring the FedNow backend port.

**Key Management Improvements:**

* Enhanced `generate_keys.py` to generate a dedicated 4096-bit RSA keypair for the FRB, storing it in the appropriate directory.