### PR TITLE
#8 Fifo/out endpoint in fednow client

### DIFF
--- a/FedSystems/MQ/main.py
+++ b/FedSystems/MQ/main.py
@@ -268,3 +268,46 @@ def mark_collected(filename: str):
         raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
+
+@message_queue.get("/FIFO/out", tags=["Files"])
+def get_fifo_out():
+    """Get the next file from the FIFO queue."""
+    try:
+        # Get latest item from incoming folder
+        # Return this item as a file response
+        # Move the file to collected folder
+        incoming_files = [f for f in os.listdir("incoming") if f.endswith('.xml')]
+        if not incoming_files:
+            raise HTTPException(status_code=404, detail="No files in FIFO queue")
+
+        # Build a list of (filename, mtime) while handling races where files
+        # may disappear between listing and stat.
+        candidates = []
+        for f in incoming_files:
+            path = os.path.join("incoming", f)
+            try:
+                mtime = os.path.getmtime(path)
+            except FileNotFoundError:
+                continue
+            candidates.append((f, mtime))
+
+        if not candidates:
+            raise HTTPException(status_code=404, detail="No files in FIFO queue")
+
+        # Select the oldest file by modification time (mtime)
+        next_file = min(candidates, key=lambda t: t[1])[0]
+        src = os.path.join("incoming", next_file)
+        dst = os.path.join("collected", next_file)
+
+        try:
+            os.replace(src, dst)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="File not found when moving")
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc))
+
+        return FileResponse(dst, filename=next_file, media_type="application/xml")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/readme.md
+++ b/readme.md
@@ -294,6 +294,19 @@ API also available at  http://localhost:8770/docs
 - http://localhost:8770/mark-collected/{filename} - Allows you to clear file from incoming to collected directory
 - http://localhost:8770/collected - Lists collected files (Used mainly for archiving)
 - http://localhost:8770/collected/{filename} - Allows you to download file from collected directory (Used mainly for archiving)
+- http://localhost:8770/FIFO/out - If no files are available in queue returns `404 - No files in queue`, if files are in queue returns oldest file, and removes file from queue. Files are moved to `/collected` for possible recovery.
+
+### How to send file
+
+- Use http://localhost:8770/send - `POST`, accepts xml files. This is where you'd send any files you want to send to FedNow service.
+- Files are automatically renamed to {BANK_RTN}_DATE_TIME_XXXX.xml"
+
+### How to recive file
+- Method 1:
+    - Use http://localhost:8770/FIFO/out - If no files are available in queue returns `404 - No files in queue`, if files are in queue returns oldest file, and removes file from queue. Files are moved to `/collected` for possible recovery.
+- Method 2:
+    - Use http://localhost:8770/incoming/{filename} to fetch specific file from incoming.
+    - Requires user to manually track files and move files out of queue with http://localhost:8770/mark-failed/{filename} or http://localhost:8770/mark-collected/{filename}
 
 # RTP System
 


### PR DESCRIPTION
This pull request introduces a new FIFO queue endpoint for retrieving files and updates the documentation to reflect this addition. The main changes include implementing the `/FIFO/out` API route to serve the oldest file in the queue and updating the `readme.md` with usage instructions for both sending and receiving files.

**API Enhancements:**

* Added a new GET endpoint `/FIFO/out` in `main.py` that returns the oldest `.xml` file from the `incoming` directory, moves it to `collected`, and serves it as a file response. If no files are available, it returns a 404 error.

**Documentation Updates:**

* Updated `readme.md` to document the new `/FIFO/out` endpoint, including expected behavior and error handling.
* Added clear instructions in `readme.md` on how to send files to the service and two methods for retrieving files, highlighting the new FIFO endpoint.