### PR TITLE
#19 Add FedNow banks API and frontend listing

### DIFF
--- a/FedSystems/FedNow/main.py
+++ b/FedSystems/FedNow/main.py
@@ -38,6 +38,20 @@ MQ_BANK3_URL = os.environ.get("MQ_BANK3_URL", "message-queue-bank3-client:8000")
 MQ_BANK4_URL = os.environ.get("MQ_BANK4_URL", "message-queue-bank4-client:8000")
 MQ_BANK5_URL = os.environ.get("MQ_BANK5_URL", "message-queue-bank5-client:8000")
 
+MQ_BANK0_LEGAL_NAME = os.environ.get("MQ_BANK0_LEGAL_NAME", "Bank 0")
+MQ_BANK1_LEGAL_NAME = os.environ.get("MQ_BANK1_LEGAL_NAME", "Bank 1")
+MQ_BANK2_LEGAL_NAME = os.environ.get("MQ_BANK2_LEGAL_NAME", "Bank 2")
+MQ_BANK3_LEGAL_NAME = os.environ.get("MQ_BANK3_LEGAL_NAME", "Bank 3")
+MQ_BANK4_LEGAL_NAME = os.environ.get("MQ_BANK4_LEGAL_NAME", "Bank 4")
+MQ_BANK5_LEGAL_NAME = os.environ.get("MQ_BANK5_LEGAL_NAME", "Bank 5")
+
+MQ_BANK0_PORT = os.environ.get("MQ_BANK0_PORT", "8000")
+MQ_BANK1_PORT = os.environ.get("MQ_BANK1_PORT", "8000")
+MQ_BANK2_PORT = os.environ.get("MQ_BANK2_PORT", "8000")
+MQ_BANK3_PORT = os.environ.get("MQ_BANK3_PORT", "8000")
+MQ_BANK4_PORT = os.environ.get("MQ_BANK4_PORT", "8000")
+MQ_BANK5_PORT = os.environ.get("MQ_BANK5_PORT", "8000")
+
 banks_ports_map = {
     MQ_BANK0_RTN: MQ_BANK0_URL,
     MQ_BANK1_RTN: MQ_BANK1_URL,
@@ -75,6 +89,17 @@ def get_frb_info():
         "routing_number": FRB_ROUTING_NUMBER,
         "legal_name": FRB_LEGAL_NAME
     }
+
+@fednow.get("/banks", tags=["Banks"])
+def list_banks():
+    return [
+        {"routing_number": MQ_BANK0_RTN, "legal_name": MQ_BANK0_LEGAL_NAME, "port": MQ_BANK0_PORT},
+        {"routing_number": MQ_BANK1_RTN, "legal_name": MQ_BANK1_LEGAL_NAME, "port": MQ_BANK1_PORT},
+        {"routing_number": MQ_BANK2_RTN, "legal_name": MQ_BANK2_LEGAL_NAME, "port": MQ_BANK2_PORT},
+        {"routing_number": MQ_BANK3_RTN, "legal_name": MQ_BANK3_LEGAL_NAME, "port": MQ_BANK3_PORT},
+        {"routing_number": MQ_BANK4_RTN, "legal_name": MQ_BANK4_LEGAL_NAME, "port": MQ_BANK4_PORT},
+        {"routing_number": MQ_BANK5_RTN, "legal_name": MQ_BANK5_LEGAL_NAME, "port": MQ_BANK5_PORT}
+    ]
 
 @fednow.post("/collect", tags=["Messages"])
 def collect_message(file: UploadFile = File(...)):

--- a/FedSystems/docker-compose.yml
+++ b/FedSystems/docker-compose.yml
@@ -117,6 +117,18 @@ services:
       - MQ_BANK3_URL=http://message-queue-bank3-client:8000
       - MQ_BANK4_URL=http://message-queue-bank4-client:8000
       - MQ_BANK5_URL=http://message-queue-bank5-client:8000
+      - MQ_BANK0_LEGAL_NAME=${BANK0_LEGAL_NAME}
+      - MQ_BANK1_LEGAL_NAME=${BANK1_LEGAL_NAME}
+      - MQ_BANK2_LEGAL_NAME=${BANK2_LEGAL_NAME}
+      - MQ_BANK3_LEGAL_NAME=${BANK3_LEGAL_NAME}
+      - MQ_BANK4_LEGAL_NAME=${BANK4_LEGAL_NAME}
+      - MQ_BANK5_LEGAL_NAME=${BANK5_LEGAL_NAME}
+      - MQ_BANK0_PORT=${MQ_BANK0_PORT}
+      - MQ_BANK1_PORT=${MQ_BANK1_PORT}
+      - MQ_BANK2_PORT=${MQ_BANK2_PORT}
+      - MQ_BANK3_PORT=${MQ_BANK3_PORT}
+      - MQ_BANK4_PORT=${MQ_BANK4_PORT}
+      - MQ_BANK5_PORT=${MQ_BANK5_PORT}
     depends_on:
       - postgres
     volumes:
@@ -149,8 +161,10 @@ services:
       - "${REACT_PORT}:5173"
     environment:
       - VITE_ACH_API_BASE_URL=http://localhost:${APP_ACH_PORT}
+      - VITE_FEDNOW_API_BASE_URL=http://localhost:${APP_FEDNOW_PORT}
     depends_on:
       - ach-backend
+      - fednow-backend
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/FedSystems/frontend/src/App.jsx
+++ b/FedSystems/frontend/src/App.jsx
@@ -13,6 +13,7 @@ const navigationItems = [
 
 function HomePage({
   apiUrl,
+  fednowApiUrl,
   backendStatus,
   onRefresh,
   onBankAdded,
@@ -20,6 +21,8 @@ function HomePage({
   sftpLoading,
   achBanks,
   achBanksLoading,
+  fednowBanks,
+  fednowBanksLoading,
   bankBalances,
   bankBalanceLoadingByRtn,
 }) {
@@ -306,11 +309,33 @@ function HomePage({
               <div className="card h-100 border-0 rounded-4" style={{ backgroundColor: '#f4effc' }}>
                 <div className="card-body p-3 p-lg-4">
                   <div className="text-uppercase text-body-secondary small fw-semibold mb-2">
-                    FedNow API Endpoint
+                    FedNow Banks Docs
                   </div>
-                  <span className="badge rounded-pill text-white fw-semibold" style={{ backgroundColor: '#6f42c1' }}>
-                    WIP
-                  </span>
+                  <div className="small text-body-secondary mb-2">
+                    Source: <a href={fednowApiUrl + '/docs'} target="_blank" rel="noopener noreferrer">FedNow API</a>
+                  </div>
+
+                  {fednowBanksLoading ? (
+                    <div>Loading FedNow banks...</div>
+                  ) : (
+                    <ul className="list-group list-group-flush rounded-3 overflow-hidden">
+                      {(!fednowBanks || fednowBanks.length === 0) && (
+                        <li className="list-group-item bg-transparent px-0">No FedNow banks found</li>
+                      )}
+                      {(fednowBanks || []).map((bank) => (
+                        <li key={bank.routing_number} className="list-group-item bg-transparent px-0 py-2 border-0">
+                          <a
+                            href={`http://localhost:${bank.port}/docs`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-decoration-none fw-semibold"
+                          >
+                            {bank.legal_name} ({bank.routing_number}) - localhost:{bank.port}/docs
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                 </div>
               </div>
             </div>
@@ -894,6 +919,11 @@ function App() {
   const [sftpLoading, setSftpLoading] = useState(false)
   const [achBanks, setAchBanks] = useState([])
   const [achBanksLoading, setAchBanksLoading] = useState(false)
+  const [fednowApiUrl] = useState(() => {
+    return import.meta.env.VITE_FEDNOW_API_BASE_URL || 'http://localhost:8000'
+  })
+  const [fednowBanks, setFednowBanks] = useState([])
+  const [fednowBanksLoading, setFednowBanksLoading] = useState(false)
   const [bankBalances, setBankBalances] = useState({})
   const [bankBalanceLoadingByRtn, setBankBalanceLoadingByRtn] = useState({})
 
@@ -983,6 +1013,27 @@ function App() {
   useEffect(() => {
     if (page !== pages.home) return
 
+    const controller = new AbortController()
+    setFednowBanksLoading(true)
+
+    fetch(`${fednowApiUrl}/banks`, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json()
+      })
+      .then((data) => setFednowBanks(Array.isArray(data) ? data : []))
+      .catch((err) => {
+        if (err.name === 'AbortError') return
+        setFednowBanks([])
+      })
+      .finally(() => setFednowBanksLoading(false))
+
+    return () => controller.abort()
+  }, [fednowApiUrl, page])
+
+  useEffect(() => {
+    if (page !== pages.home) return
+
     const rtNs = (achBanks || [])
       .map((b) => b.master_account_rtn)
       .filter((rtn) => rtn !== null && rtn !== undefined)
@@ -1059,12 +1110,15 @@ function App() {
     return (
       <HomePage
         apiUrl={apiUrl}
+        fednowApiUrl={fednowApiUrl}
         backendStatus={backendStatus}
         onRefresh={refreshBackendStatus}
         sftpUsers={sftpUsers}
         sftpLoading={sftpLoading}
         achBanks={achBanks}
         achBanksLoading={achBanksLoading}
+        fednowBanks={fednowBanks}
+        fednowBanksLoading={fednowBanksLoading}
         bankBalances={bankBalances}
         bankBalanceLoadingByRtn={bankBalanceLoadingByRtn}
         onBankAdded={loadAchBanks}


### PR DESCRIPTION
Introduce a /banks endpoint that returns each FedNow bank's routing_number, legal_name and port (defaults read from new MQ_BANK{0..5}_LEGAL_NAME and MQ_BANK{0..5}_PORT env vars). Update docker-compose to pass the new legal name and port environment variables and to expose VITE_FEDNOW_API_BASE_URL to the frontend, as well as add a dependency on the fednow backend. Update the frontend to read VITE_FEDNOW_API_BASE_URL, fetch the banks list, and render links to each bank's /docs. This surfaces FedNow banks in the UI and enables linking to their local docs endpoints.