### PR TITLE
#27 #28 Resolve message processing and bank mapping logic

### DIFF
--- a/FedSystems/FedNow/main.py
+++ b/FedSystems/FedNow/main.py
@@ -124,12 +124,12 @@ port_maps = {
 }
 
 port_to_name_map = {
-    MQ_BANK0_PORT: MQ_BANK0_LEGAL_NAME,
-    MQ_BANK1_PORT: MQ_BANK1_LEGAL_NAME,
-    MQ_BANK2_PORT: MQ_BANK2_LEGAL_NAME,
-    MQ_BANK3_PORT: MQ_BANK3_LEGAL_NAME,
-    MQ_BANK4_PORT: MQ_BANK4_LEGAL_NAME,
-    MQ_BANK5_PORT: MQ_BANK5_LEGAL_NAME,
+    MQ_BANK0_PORT: MQ_BANK0_RTN,
+    MQ_BANK1_PORT: MQ_BANK1_RTN,
+    MQ_BANK2_PORT: MQ_BANK2_RTN,
+    MQ_BANK3_PORT: MQ_BANK3_RTN,
+    MQ_BANK4_PORT: MQ_BANK4_RTN,
+    MQ_BANK5_PORT: MQ_BANK5_RTN,
     MQ_MERCHANT0_PORT: MERCHANT0_NAME,
 }
 
@@ -944,10 +944,6 @@ def _process_pacs002_message(message: pacs002Message):
                         interested_party=party
                     )
             return
-        else:
-            if DEBUG:
-                print(f"No matching pending message found for pacs.002 with EndToEndId: {end_to_end_id}. pacs.002 should always be related to a pacs.008. Ignoring this message.")
-            raise HTTPException(status_code=400, detail=f"No matching pending message found for pacs.002 with EndToEndId: {end_to_end_id}. pacs.002 should always be related to a pacs.008.")
         
     for completed in completed_messages:
         if completed.endToEndId == end_to_end_id:


### PR DESCRIPTION
#### Changes

1. #27 :
    * Removed the premature `else` block within the `_process_pacs002_message` loop that caused valid messages to fail if they were not the first item in the `pending_messages` list.


2. #28 :
    * Updated `port_to_name_map` to use **RTNs** (Routing Transit Numbers) instead of Legal Names. This ensures the configuration keys align with the upstream identification logic used in `banks_ports_map`, resolving routing failures for `pain.013` and `pain.014` messages.

#### Testing

* Verified that `pacs.002` messages with multiple `pacs.008` messages in the queue now correctly match their `EndToEndId`.
* Verified that the `pain.013`/`pain.014` bank routing logic successfully resolves the `endpoint_base` using RTNs.